### PR TITLE
Allow for environments besides "development" and "production"

### DIFF
--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -18,7 +18,7 @@ module.exports = function (data) {
 
                 if (path.node.source.value === options.replacedModuleName) {
                   var config = dotEnv.config({ path: sysPath.join(configDir, '.env'), silent: true }) || {};
-                  var platformPath = (process.env.BABEL_ENV === 'development' || process.env.BABEL_ENV === undefined) ? '.env.development' : '.env.production';
+                  var platformPath = '.env.' + (process.env.BABEL_ENV || 'development');
                   var config = Object.assign(config, dotEnv.config({ path: sysPath.join(configDir, platformPath), silent: true }));
 
                   path.node.specifiers.forEach(function(specifier, idx){

--- a/babel-plugin-dotenv/test/fixtures/other-env/.babelrc
+++ b/babel-plugin-dotenv/test/fixtures/other-env/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "babel-plugin-transform-es2015-modules-commonjs",
+    ["../../../", {
+      "replacedModuleName": "babel-dotenv",
+      "configDir": "test/fixtures/other-env"
+    }],
+  ]
+}

--- a/babel-plugin-dotenv/test/fixtures/other-env/.env
+++ b/babel-plugin-dotenv/test/fixtures/other-env/.env
@@ -1,0 +1,2 @@
+API_KEY=abc123
+DEV_USERNAME=username

--- a/babel-plugin-dotenv/test/fixtures/other-env/.env.development
+++ b/babel-plugin-dotenv/test/fixtures/other-env/.env.development
@@ -1,0 +1,1 @@
+DEV_USERNAME=userdonthavename

--- a/babel-plugin-dotenv/test/fixtures/other-env/.env.other
+++ b/babel-plugin-dotenv/test/fixtures/other-env/.env.other
@@ -1,0 +1,1 @@
+DEV_USERNAME=otherfoobar

--- a/babel-plugin-dotenv/test/fixtures/other-env/.env.production
+++ b/babel-plugin-dotenv/test/fixtures/other-env/.env.production
@@ -1,0 +1,1 @@
+DEV_USERNAME=foobar

--- a/babel-plugin-dotenv/test/fixtures/other-env/source.js
+++ b/babel-plugin-dotenv/test/fixtures/other-env/source.js
@@ -1,0 +1,3 @@
+import { API_KEY, DEV_USERNAME } from 'babel-dotenv';
+console.log(API_KEY);
+console.log(DEV_USERNAME);

--- a/babel-plugin-dotenv/test/test.js
+++ b/babel-plugin-dotenv/test/test.js
@@ -44,6 +44,13 @@ describe('myself in some tests', function() {
     process.env['BABEL_ENV'] = undefined;
   })
 
+  it('should load let .env.<babel env> overwrite .env', function(){
+    process.env['BABEL_ENV'] = 'other';
+    var result = babel.transformFileSync('test/fixtures/other-env/source.js')
+    expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'otherfoobar\');')
+    process.env['BABEL_ENV'] = undefined;
+  })
+
   it('should support `as alias` import syntax', function(){
     var result = babel.transformFileSync('test/fixtures/as-alias/source.js')
     expect(result.code).to.be('\'use strict\';\n\nvar a = \'abc123\';\nvar b = \'username\';')


### PR DESCRIPTION
Sometimes it can be handy to have other environments (I usually end up with `test` and `staging` environments), so I've tweaked things to just look for a `.env` file that matches the `BABEL_ENV`, but it'll still default to `.env.development`.