### PR TITLE
Add filename option.

### DIFF
--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -32,7 +32,7 @@ module.exports = function (data) {
                     var localId = specifier.local.name;
 
                     if(!config[importedId]) {
-                      throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any .env files.')
+                      throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any ' + configFile + ' files.')
                     }
 
                     var binding = path.scope.getBinding(localId);

--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -15,10 +15,13 @@ module.exports = function (data) {
                   return;
 
                 var configDir = options.configDir ? options.configDir : './';
+                var configFile = options.filename ? options.filename : '.env';
 
                 if (path.node.source.value === options.replacedModuleName) {
-                  var config = dotEnv.config({ path: sysPath.join(configDir, '.env'), silent: true }) || {};
-                  var platformPath = (process.env.BABEL_ENV === 'development' || process.env.BABEL_ENV === undefined) ? '.env.development' : '.env.production';
+                  var config = dotEnv.config({ path: sysPath.join(configDir, configFile), silent: true }) || {};
+                  var platformPath = (process.env.BABEL_ENV === 'development' || process.env.BABEL_ENV === undefined)
+                                          ? configFile + '.development'
+                                          : configFile + '.production';
                   var config = Object.assign(config, dotEnv.config({ path: sysPath.join(configDir, platformPath), silent: true }));
 
                   path.node.specifiers.forEach(function(specifier, idx){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dotenv",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A Babel preset let you `import` application configs from **.env** file (zero runtime dependency)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi zetachang,

I add a new option 'filename' to your babel-plugin-dotenv package to allow user to customize the filename of .env file. For example, in my project, I change it to 'build.env'. 

please review it.