### PR TITLE
Update for react-native 0.46

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var config = require("metro-bundler/rn-cli.config");
+var config = require("metro-bundler/build/rn-cli.config");
 
 module.exports = {
   plugins: [

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var config = require("react-native/packager/rn-cli.config");
+var config = require("metro-bundler/rn-cli.config");
 
 module.exports = {
   plugins: [


### PR DESCRIPTION
`/packager` has been removed in favor of `metro-bundler`