### PR TITLE
Remove Exception if imported var does not exist

### DIFF
--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -31,15 +31,13 @@ module.exports = function (data) {
                     var importedId = specifier.imported.name
                     var localId = specifier.local.name;
 
-                    if(!config[importedId]) {
-                      throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any ' + configFile + ' files.')
+                    if(!config.hasOwnProperty(importedId)) {
+                      config[importedId] = null;
                     }
 
                     var binding = path.scope.getBinding(localId);
                     binding.referencePaths.forEach(function(refPath){
-                      if (config[importedId]) {
-                        refPath.replaceWith(t.valueToNode(config[importedId]))
-                      }
+                      refPath.replaceWith(t.valueToNode(config[importedId]));
                     });
                   })
 


### PR DESCRIPTION
Allows you to `import { MY_VAR, MY_OPT } from 'react-native-dotenv'` even if the var is not defined in the env file or if the env file doesn't exist. Throwing an exception removes the optional nature of an .env file.
As mentioned in [this issue](https://github.com/zetachang/react-native-dotenv/issues/10) rather give the dev the option to assign the variable conditionally: `myconfig.MY_VAR = MY_VAR || 'default'`