### PR TITLE
Multi Environments

### DIFF
--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -18,10 +18,15 @@ module.exports = function (data) {
                 var configFile = options.filename ? options.filename : '.env';
 
                 if (path.node.source.value === options.replacedModuleName) {
+                  var babelEnv = process.env.BABEL_ENV;
+                  var env = (!babelEnv || babelEnv === 'development') ? 'development' : 'production';
+                  var platformPath = configFile + '.' + env;
+
+                  if (process.env.ENV_FILE) {
+                    platformPath = process.env.ENV_FILE;
+                  }
+
                   var config = dotEnv.config({ path: sysPath.join(configDir, configFile), silent: true }) || {};
-                  var platformPath = (process.env.BABEL_ENV === 'development' || process.env.BABEL_ENV === undefined)
-                                          ? configFile + '.development'
-                                          : configFile + '.production';
                   var config = Object.assign(config, dotEnv.config({ path: sysPath.join(configDir, platformPath), silent: true }));
 
                   path.node.specifiers.forEach(function(specifier, idx){

--- a/babel-plugin-dotenv/test/fixtures/beta-env/.babelrc
+++ b/babel-plugin-dotenv/test/fixtures/beta-env/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "babel-plugin-transform-es2015-modules-commonjs",
+    ["../../../", {
+      "replacedModuleName": "babel-dotenv",
+      "configDir": "test/fixtures/beta-env"
+    }],
+  ]
+}

--- a/babel-plugin-dotenv/test/fixtures/beta-env/.env
+++ b/babel-plugin-dotenv/test/fixtures/beta-env/.env
@@ -1,0 +1,2 @@
+API_KEY=abc123
+DEV_USERNAME=username

--- a/babel-plugin-dotenv/test/fixtures/beta-env/.env.beta
+++ b/babel-plugin-dotenv/test/fixtures/beta-env/.env.beta
@@ -1,0 +1,1 @@
+DEV_USERNAME=foobar

--- a/babel-plugin-dotenv/test/fixtures/beta-env/.env.development
+++ b/babel-plugin-dotenv/test/fixtures/beta-env/.env.development
@@ -1,0 +1,1 @@
+DEV_USERNAME=userdonthavename

--- a/babel-plugin-dotenv/test/fixtures/beta-env/source.js
+++ b/babel-plugin-dotenv/test/fixtures/beta-env/source.js
@@ -1,0 +1,3 @@
+import { API_KEY, DEV_USERNAME } from 'babel-dotenv';
+console.log(API_KEY);
+console.log(DEV_USERNAME);

--- a/babel-plugin-dotenv/test/fixtures/filename-from-env_file/.anyname
+++ b/babel-plugin-dotenv/test/fixtures/filename-from-env_file/.anyname
@@ -1,0 +1,2 @@
+API_KEY=abc123
+DEV_USERNAME=username

--- a/babel-plugin-dotenv/test/fixtures/filename-from-env_file/.babelrc
+++ b/babel-plugin-dotenv/test/fixtures/filename-from-env_file/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "babel-plugin-transform-es2015-modules-commonjs",
+    ["../../../", {
+      "replacedModuleName": "babel-dotenv",
+      "configDir": "test/fixtures/filename-from-env_file"
+    }]
+  ]
+}

--- a/babel-plugin-dotenv/test/fixtures/filename-from-env_file/source.js
+++ b/babel-plugin-dotenv/test/fixtures/filename-from-env_file/source.js
@@ -1,0 +1,3 @@
+import { API_KEY, DEV_USERNAME } from 'babel-dotenv';
+console.log(API_KEY);
+console.log(DEV_USERNAME);

--- a/babel-plugin-dotenv/test/test.js
+++ b/babel-plugin-dotenv/test/test.js
@@ -58,4 +58,18 @@ describe('myself in some tests', function() {
     var result = babel.transformFileSync('test/fixtures/replaced-module-name-not-provided/source.js')
     expect(result.code).to.be('\'use strict\';\n\nvar _fancyDotenv = require(\'fancy-dotenv\');\n\nvar _fancyDotenv2 = _interopRequireDefault(_fancyDotenv);\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }')
   })
+
+  it('should load a specific env file according to ENV_FILE', function(){
+    process.env['ENV_FILE'] = '.anyname';
+    var result = babel.transformFileSync('test/fixtures/filename-from-env_file/source.js')
+    expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'username\');')
+    process.env['ENV_FILE'] = undefined;
+  })
+
+  it('should load let .env.beta overwrite .env', function(){
+    process.env['ENV_FILE'] = '.env.beta';
+    var result = babel.transformFileSync('test/fixtures/beta-env/source.js')
+    expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'foobar\');')
+    process.env['ENV_FILE'] = undefined;
+  })
 });


### PR DESCRIPTION
Yeah! I know many people have been asking for multi environments. I don't wanna boring you one more time, but I have done some changes to permit that it works. ;)

I know that Babel uses just development or production options, for this reason I changed to read other variable (ENV_FILE) first.

Examples with Expo:
ENV_FILE=.env.production exp p
ENV_FILE=.env.beta exp p --release-channel beta

At my company we have used this solution, and it works pretty well. 

I also wrote some tests. So, you decide if it's worth to be included in the project. Even though it is a Babel Plugin, I think so. :)

I created this repository https://github.com/gcorreaalves/babel-plugin-dotenv just to install the package with the new changes for while, otherwise it doesn't work, but if you accept my PR you can republish it on NPM.