### PR TITLE
feature: Empty .env variables become empty strings

### DIFF
--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -30,14 +30,13 @@ module.exports = function (data) {
                     }
                     var importedId = specifier.imported.name
                     var localId = specifier.local.name;
-
-                    if(!config[importedId]) {
+                    if(!(importedId in config)) {
                       throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any ' + configFile + ' files.')
                     }
 
                     var binding = path.scope.getBinding(localId);
                     binding.referencePaths.forEach(function(refPath){
-                      if (config[importedId]) {
+                      if ((importedId in config)) {
                         refPath.replaceWith(t.valueToNode(config[importedId]))
                       }
                     });

--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -30,15 +30,13 @@ module.exports = function (data) {
                     }
                     var importedId = specifier.imported.name
                     var localId = specifier.local.name;
-                    if(!(importedId in config)) {
+                    if(!(config.hasOwnProperty(importedId))) {
                       throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any ' + configFile + ' files.')
                     }
 
                     var binding = path.scope.getBinding(localId);
                     binding.referencePaths.forEach(function(refPath){
-                      if ((importedId in config)) {
-                        refPath.replaceWith(t.valueToNode(config[importedId]))
-                      }
+                      refPath.replaceWith(t.valueToNode(config[importedId]))
                     });
                   })
 

--- a/babel-plugin-dotenv/test/fixtures/empty-values/.babelrc
+++ b/babel-plugin-dotenv/test/fixtures/empty-values/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "babel-plugin-transform-es2015-modules-commonjs",
+    ["../../../", {
+      "replacedModuleName": "babel-dotenv",
+      "configDir": "test/fixtures/empty-values"
+    }],
+  ]
+}

--- a/babel-plugin-dotenv/test/fixtures/empty-values/.env
+++ b/babel-plugin-dotenv/test/fixtures/empty-values/.env
@@ -1,0 +1,3 @@
+API_KEY=abc123
+DEV_USERNAME=username
+DEV_PASSWORD=

--- a/babel-plugin-dotenv/test/fixtures/empty-values/source.js
+++ b/babel-plugin-dotenv/test/fixtures/empty-values/source.js
@@ -1,0 +1,4 @@
+import { API_KEY, DEV_USERNAME, DEV_PASSWORD } from 'babel-dotenv';
+console.log(API_KEY);
+console.log(DEV_USERNAME);
+console.log(DEV_PASSWORD);

--- a/babel-plugin-dotenv/test/test.js
+++ b/babel-plugin-dotenv/test/test.js
@@ -32,6 +32,11 @@ describe('myself in some tests', function() {
     expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'username\');')
   })
 
+  it('should load empty variable as empty string ', function(){
+    var result = babel.transformFileSync('test/fixtures/empty-values/source.js')
+    expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'username\');\nconsole.log(\'\');')
+  })
+
   it('should load let .env.development overwrite .env', function(){
     var result = babel.transformFileSync('test/fixtures/dev-env/source.js')
     expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'userdonthavename\');')


### PR DESCRIPTION
As stated in [`dotenv` Rules](https://github.com/motdotla/dotenv/#rules): 
> * empty values become empty strings (EMPTY= becomes {EMPTY: ''})

I added a test which is passing. I don't know if any further action is required such as a version bump or something like that, please let me know to do add it to the PR!