### PR TITLE
Updates for RN 0.56.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the `react-native-dotenv` preset to your **.babelrc** file at the project ro
 
 ```json
 {
-  "presets": ["react-native", "react-native-dotenv"]
+  "presets": ["react-native", "module:react-native-dotenv"]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var path = require('path');
 
-module.exports = {
+module.exports = () => ({
   plugins: [
     [require('babel-plugin-dotenv'), {
       replacedModuleName: 'react-native-dotenv',
       configDir: path.resolve(__dirname, "../../")
     }],
   ],
-};
+});


### PR DESCRIPTION
I got two errors when I tried to run my project with RN 0.56.0-rc.2:

* error: bundling failed: Error: Cannot find module 'babel-preset-react-native-dotenv' from 'project'
- If you want to resolve "react-native-dotenv", use "module:react-native-dotenv"

* error: bundling failed: Error: Plugin/Preset files are not allowed to export objects, only functions. In project/node_modules/react-native-dotenv/index.js