### PR TITLE
override values from .env with values form environment variables

### DIFF
--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -3,6 +3,8 @@ var fs = require('fs');
 var sysPath = require('path');
 var process = require('process');
 
+var environmentCopy = Object.assign({}, process.env)
+
 module.exports = function (data) {
     var t = data.types;
 
@@ -30,19 +32,19 @@ module.exports = function (data) {
                     }
                     var importedId = specifier.imported.name
                     var localId = specifier.local.name;
-                    if(!(config.hasOwnProperty(importedId)) && !process.env.hasOwnProperty(importedId)) {
+                    if(!(config.hasOwnProperty(importedId)) && !environmentCopy.hasOwnProperty(importedId)) {
                       throw path.get('specifiers')[idx].buildCodeFrameError(
                         'Try to import dotenv variable "'
                         + importedId
                         + '" which is not defined in any '
                         + configFile
-                        + ' files or as environment variable.'
+                        + ' files or as an environment variable.'
                       )
                     }
 
                     var binding = path.scope.getBinding(localId);
                     binding.referencePaths.forEach(function(refPath){
-                      refPath.replaceWith(t.valueToNode(process.env[importedId] || config[importedId]))
+                      refPath.replaceWith(t.valueToNode(environmentCopy[importedId] || config[importedId]))
                     });
                   })
 

--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -30,13 +30,19 @@ module.exports = function (data) {
                     }
                     var importedId = specifier.imported.name
                     var localId = specifier.local.name;
-                    if(!(config.hasOwnProperty(importedId))) {
-                      throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any ' + configFile + ' files.')
+                    if(!(config.hasOwnProperty(importedId)) && !process.env.hasOwnProperty(importedId)) {
+                      throw path.get('specifiers')[idx].buildCodeFrameError(
+                        'Try to import dotenv variable "'
+                        + importedId
+                        + '" which is not defined in any '
+                        + configFile
+                        + ' files or as environment variable.'
+                      )
                     }
 
                     var binding = path.scope.getBinding(localId);
                     binding.referencePaths.forEach(function(refPath){
-                      refPath.replaceWith(t.valueToNode(config[importedId]))
+                      refPath.replaceWith(t.valueToNode(process.env[importedId] || config[importedId]))
                     });
                   })
 

--- a/babel-plugin-dotenv/test/fixtures/override-value/.babelrc
+++ b/babel-plugin-dotenv/test/fixtures/override-value/.babelrc
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    "babel-plugin-transform-es2015-modules-commonjs",
+    ["../../../", {
+      "replacedModuleName": "babel-dotenv",
+      "configDir": "test/fixtures/default"
+    }]
+  ]
+}
+

--- a/babel-plugin-dotenv/test/fixtures/override-value/.env
+++ b/babel-plugin-dotenv/test/fixtures/override-value/.env
@@ -1,0 +1,2 @@
+FOO_ENV=abc123
+

--- a/babel-plugin-dotenv/test/fixtures/override-value/source.js
+++ b/babel-plugin-dotenv/test/fixtures/override-value/source.js
@@ -1,0 +1,2 @@
+import { FOO_ENV } from 'babel-dotenv';
+console.log(FOO_ENV);

--- a/babel-plugin-dotenv/test/test.js
+++ b/babel-plugin-dotenv/test/test.js
@@ -11,11 +11,19 @@ var createPluginsWithConfigDir = function(configDir) {
 }
 
 describe('myself in some tests', function() {
-  it('should throw if variable not exist', function() {
+  before(function() {
+    process.env.FOO_ENV = 'foo'
+  })
+
+  after(function() {
+    delete process.env.FOO_ENV
+  })
+
+  it('should throw if variable not exist and no environemnt variable is defined', function() {
     expect(function(){
       babel.transformFileSync('test/fixtures/variable-not-exist/source.js')
     }).to.throwException(function (e) {
-      expect(e.message).to.contain("Try to import dotenv variable \"foo\" which is not defined in any .env files.");
+      expect(e.message).to.contain("Try to import dotenv variable \"foo\" which is not defined in any .env files or as an environment variable.");
     });
   });
 
@@ -26,6 +34,11 @@ describe('myself in some tests', function() {
       expect(e.message).to.contain("Import dotenv as default is not supported.");
     });
   });
+
+  it('should override values defined in .env with environment variable', function() {
+    var result = babel.transformFileSync('test/fixtures/override-value/source.js')
+    expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'foo\');')
+  })
 
   it('should load default env from .env', function(){
     var result = babel.transformFileSync('test/fixtures/default/source.js')

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var path = require('path');
 
 module.exports = () => ({
   plugins: [
-    [require('babel-plugin-dotenv'), {
+    [require('./babel-plugin-dotenv'), {
       replacedModuleName: 'react-native-dotenv',
       configDir: path.resolve(__dirname, "../../")
     }],


### PR DESCRIPTION
according to dotenv documentation:

> What happens to environment variables that were already set?
We will never modify any environment variables that have already been set. In particular, if there is a variable in your .env file which collides with one that already exists in your environment, then that variable will be skipped. This behavior allows you to override all .env configurations with a machine-specific environment, although it is not recommended.

What this PR does:
- if a value is present on environment variable it overrides the value that is on the .env files

Why is this needed:
- to align more with how dotenv lib functions
- to make it easier for CI/CD piple to define the env vars

fixes #37