### PR TITLE
[allow-undefined] closes #41

### DIFF
--- a/babel-plugin-dotenv/index.js
+++ b/babel-plugin-dotenv/index.js
@@ -30,10 +30,6 @@ module.exports = function (data) {
                     }
                     var importedId = specifier.imported.name
                     var localId = specifier.local.name;
-                    if(!(config.hasOwnProperty(importedId))) {
-                      throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any ' + configFile + ' files.')
-                    }
-
                     var binding = path.scope.getBinding(localId);
                     binding.referencePaths.forEach(function(refPath){
                       refPath.replaceWith(t.valueToNode(config[importedId]))

--- a/babel-plugin-dotenv/test/fixtures/variable-not-exist/source.js
+++ b/babel-plugin-dotenv/test/fixtures/variable-not-exist/source.js
@@ -1,1 +1,2 @@
 import { foo } from "babel-dotenv";
+console.log(foo);

--- a/babel-plugin-dotenv/test/test.js
+++ b/babel-plugin-dotenv/test/test.js
@@ -11,12 +11,10 @@ var createPluginsWithConfigDir = function(configDir) {
 }
 
 describe('myself in some tests', function() {
-  it('should throw if variable not exist', function() {
-    expect(function(){
-      babel.transformFileSync('test/fixtures/variable-not-exist/source.js')
-    }).to.throwException(function (e) {
-      expect(e.message).to.contain("Try to import dotenv variable \"foo\" which is not defined in any .env files.");
-    });
+  it('should set to undefined if variable does not exist', function() {
+    const result = babel.transformFileSync('test/fixtures/variable-not-exist/source.js')
+    console.log(result.code)
+    expect(result.code).to.be('"use strict";\n\nconsole.log(undefined);')
   });
 
   it('should throw if default is imported', function() {


### PR DESCRIPTION
Allow for vars to be undefined like most other dotenv libraries do. 